### PR TITLE
Add admin flow for inviting users to business

### DIFF
--- a/components/AssociatedUsers.vue
+++ b/components/AssociatedUsers.vue
@@ -102,9 +102,9 @@ const props = defineProps<{ businessName?: string }>()
 const store           = useUserStore()
 const user: any       = store.getUser
 const assocId         = user[`associated_${user.type}_id`]
-const allUsers        = store.getAllUsers
-
-const associatedUsers = ref<any[]>([])
+const associatedUsers = computed(() =>
+    store.getAllUsers.filter((u: any) => u[`associated_${user.type}_id`] === assocId)
+)
 const openDialog      = ref(false)
 const headerTitle     = ref('')
 const loading         = ref(false)
@@ -125,14 +125,11 @@ const errDialog       = ref(false)
 const errMsg          = ref()
 const errType         = ref()
 
-onMounted(() => {
-    getAssociatedUsers()
+onMounted(async () => {
+    await store.loadUsers()
 })
 
-const getAssociatedUsers = () => {
-    associatedUsers.value = allUsers
-        .filter((u: any) => u[`associated_${user.type}_id`] === assocId)
-}
+const refreshUsers = () => store.loadUsers()
 
 const inviteUser = async () => {
     if (!email.value) {
@@ -161,7 +158,7 @@ const inviteUser = async () => {
         snacktext.value = 'Invite sent!'
 
         resetFields()
-        getAssociatedUsers()
+        refreshUsers()
         openDialog.value = false
     } catch (error: any) {
         errType.value = 'User Invite'
@@ -205,7 +202,7 @@ const submitEdits = async () => {
         snacktext.value = 'User updated!'
 
         resetFields()
-        getAssociatedUsers()
+        refreshUsers()
         openDialog.value = false
     } catch (error: any) {
         errType.value = 'User Update(s)'
@@ -232,7 +229,7 @@ const confirmDelete = async () => {
         snackbar.value = true
         snacktext.value = 'User deleted.'
 
-        getAssociatedUsers()
+        refreshUsers()
         deleteDialog.value = false
         userToDelete.value = null
     } catch (error: any) {

--- a/components/AssociatedUsers.vue
+++ b/components/AssociatedUsers.vue
@@ -3,12 +3,13 @@
         <DataTable :value="associatedUsers">
             <template #header>
                 <div class="flex flex-wrap items-center justify-between gap-2">
-                    <span class="text-xl font-bold">Menu Items</span>
+                    <span class="text-xl font-bold">Users</span>
                     <Button
                         outlined
                         severity="secondary"
                         icon="pi pi-plus-circle"
-                        @click="addDialog = true"
+                        label="Invite User"
+                        @click="openAddDialog"
                     />
                 </div>
             </template>
@@ -32,6 +33,12 @@
                     {{ slotProps.data.phone }}
                 </template>
             </Column>
+            <Column field="registered" header="Status">
+                <template #body="slotProps">
+                    <Tag v-if="slotProps.data.registered" severity="success" value="Active" />
+                    <Tag v-else severity="warn" value="Invited" />
+                </template>
+            </Column>
             <Column field="actions">
                 <template #body="{ data }">
                     <Button icon="pi pi-pencil" outlined rounded class="mr-2" @click="openEditDialog(data)" />
@@ -40,7 +47,7 @@
             </Column>
         </DataTable>
 
-        <!-- ADD USER -->
+        <!-- ADD/EDIT USER DIALOG -->
         <Dialog v-model:visible="openDialog" modal :header="`${headerTitle} User`" :style="{ width: '35rem' }">
             <div class="flex flex-wrap gap-4 m-2">
                 <div class="w-full md:w-1/2 p-2">
@@ -57,7 +64,7 @@
                 </div>
                 <div class="w-full md:w-1/2 p-2">
                     <FloatLabel variant="on">
-                        <InputText id="email" v-model="email" />
+                        <InputText id="email" v-model="email" :disabled="headerTitle === 'Edit'" />
                         <label for="email">Email</label>
                     </FloatLabel>
                 </div>
@@ -77,7 +84,7 @@
                 </div>
             </div>
             <div class="flex gap-2 p-2">
-                <Button v-if="headerTitle == 'Add'" @click="addUser" block :loading="loading">Add User</Button>
+                <Button v-if="headerTitle == 'Add'" @click="inviteUser" block :loading="loading">Send Invite</Button>
                 <Button v-if="headerTitle == 'Edit'" @click="submitEdits" block :loading="loading">Submit Edits</Button>
             </div>
         </Dialog>
@@ -90,23 +97,23 @@
 </template>
 
 <script setup lang="ts">
-import { v4 } from 'uuid';
+const props = defineProps<{ businessName?: string }>()
+
 const store           = useUserStore()
-const user:any        = store.getUser
+const user: any       = store.getUser
 const assocId         = user[`associated_${user.type}_id`]
 const allUsers        = store.getAllUsers
 
-const associatedUsers = ref()
+const associatedUsers = ref<any[]>([])
 const openDialog      = ref(false)
 const headerTitle     = ref('')
 const loading         = ref(false)
 const snackbar        = ref(false)
 const snacktext       = ref('')
-const userToDelete    = ref(null)
+const userToDelete    = ref<any>(null)
 const deleteDialog    = ref(false)
 const editId          = ref('')
 
-// USER DATA 
 const first           = ref('')
 const last            = ref('')
 const isAdmin         = ref(false)
@@ -124,50 +131,59 @@ onMounted(() => {
 
 const getAssociatedUsers = () => {
     associatedUsers.value = allUsers
-        .filter((user:any) => user[`associated_${user.type}_id`] === assocId)
+        .filter((u: any) => u[`associated_${user.type}_id`] === assocId)
 }
 
-const addUser = async () => {
-    const userObj = {
-        created_at: new Date(),
-        is_admin: isAdmin.value,
-        first_name: first.value,
-        last_name: last.value,
-        phone: phone.value,
-        email: email.value,
-        type: user.type,
-        id: v4(),
-        available_to_contact: available.value,
-        associated_merchant_id: user.type == 'merchant' ? user[`associated_${user.type}_id`] : null,
-        associated_vendor_id: user.type == 'vendor' ? user[`associated_${user.type}_id`] : null,
+const inviteUser = async () => {
+    if (!email.value) {
+        errType.value = 'Validation'
+        errMsg.value = 'Email is required to send an invite'
+        errDialog.value = true
+        return
     }
+
+    loading.value = true
     try {
-        await store.createUser(userObj)
+        await store.inviteUser({
+            email: email.value,
+            firstName: first.value || undefined,
+            lastName: last.value || undefined,
+            phone: phone.value || undefined,
+            isAdmin: isAdmin.value,
+            availableToContact: available.value,
+            type: user.type,
+            associatedMerchantId: user.type === 'merchant' ? assocId : null,
+            associatedVendorId: user.type === 'vendor' ? assocId : null,
+            businessName: props.businessName
+        })
+
         snackbar.value = true
-        snacktext.value = 'New user added!'
+        snacktext.value = 'Invite sent!'
 
         resetFields()
-
         getAssociatedUsers()
         openDialog.value = false
     } catch (error: any) {
-        errType.value = 'User Creation'
-        errMsg.value = error.message || 'Failed to create user'
+        errType.value = 'User Invite'
+        errMsg.value = error.data?.statusMessage || error.message || 'Failed to invite user'
         errDialog.value = true
+    } finally {
+        loading.value = false
     }
 }
+
 const openAddDialog = () => {
     headerTitle.value = 'Add'
     openDialog.value = true
 }
-const openEditDialog = (user: any) => {
-    editId.value = user.id
-    first.value = user.first_name
-    last.value = user.last_name
-    isAdmin.value = user.is_admin
-    available.value = user.available_to_contact
-    email.value = user.email
-    phone.value = user.phone
+const openEditDialog = (userData: any) => {
+    editId.value = userData.id
+    first.value = userData.first_name
+    last.value = userData.last_name
+    isAdmin.value = userData.is_admin
+    available.value = userData.available_to_contact
+    email.value = userData.email
+    phone.value = userData.phone
 
     headerTitle.value = 'Edit'
     openDialog.value = true
@@ -226,7 +242,6 @@ const confirmDelete = async () => {
     }
 }
 const cancelDelete = () => {
-    console.log('delete canceled!')
     deleteDialog.value = false
     userToDelete.value = null
 }

--- a/components/merchant/Settings.vue
+++ b/components/merchant/Settings.vue
@@ -355,10 +355,10 @@
             />
         </div>
 
-        <!-- USER MANAGEMENT TAB -->
-        <div v-if="activeTab === 4" class="space-y-6">
+        <!-- USER MANAGEMENT TAB (admin only) -->
+        <div v-if="isAdmin && activeTab === 4" class="space-y-6">
           <h2 class="text-2xl font-bold mb-6" style="color: var(--p-text-color);">User Management</h2>
-          <AssociatedUsers />
+          <AssociatedUsers :businessName="merchant.merchant_name" />
         </div>
       </div>
       
@@ -427,14 +427,21 @@ const businessHours = ref([
   { name: 'Sunday', dayOfWeek: 0, open: null, close: null, isClosed: false }
 ])
 
-// Tab configuration
-const tabs = [
-  { label: 'General Information', icon: 'pi pi-info-circle' },
-  { label: 'Business Hours', icon: 'pi pi-clock' },
-  { label: 'Payments & Financial', icon: 'pi pi-credit-card' },
-  { label: 'Compliance & Documents', icon: 'pi pi-file-pdf' },
-  { label: 'User Management', icon: 'pi pi-users' }
-]
+// Tab configuration - User Management only visible to admins
+const isAdmin = computed(() => user?.is_admin === true)
+
+const tabs = computed(() => {
+  const baseTabs = [
+    { label: 'General Information', icon: 'pi pi-info-circle' },
+    { label: 'Business Hours', icon: 'pi pi-clock' },
+    { label: 'Payments & Financial', icon: 'pi pi-credit-card' },
+    { label: 'Compliance & Documents', icon: 'pi pi-file-pdf' },
+  ]
+  if (isAdmin.value) {
+    baseTabs.push({ label: 'User Management', icon: 'pi pi-users' })
+  }
+  return baseTabs
+})
 // Subscription status
 const hasActiveSubscription = ref(false)
 const currentSubscription = ref<any>(null)

--- a/components/vendor/Settings.vue
+++ b/components/vendor/Settings.vue
@@ -353,10 +353,10 @@
           />
         </Dialog>
 
-        <!-- USER MANAGEMENT TAB -->
-        <div v-if="activeTab === 5" class="space-y-6">
+        <!-- USER MANAGEMENT TAB (admin only) -->
+        <div v-if="isAdmin && activeTab === 5" class="space-y-6">
           <h2 class="text-2xl font-bold mb-6" style="color: var(--p-text-color);">User Management</h2>
-          <AssociatedUsers />
+          <AssociatedUsers :businessName="vendor.vendor_name" />
         </div>
       </div>
     </div>
@@ -452,15 +452,22 @@ const cuisines = ref([
   'Vegan'
 ])
 
-// Tab configuration
-const tabs = [
-  { label: 'General Information', icon: 'pi pi-info-circle' },
-  { label: 'Business Hours', icon: 'pi pi-clock' },
-  { label: 'Menu', icon: 'pi pi-list' },
-  { label: 'Compliance & Documents', icon: 'pi pi-file-pdf' },
-  { label: 'Financials & Payment Settings', icon: 'pi pi-credit-card' },
-  { label: 'User Management', icon: 'pi pi-users' }
-]
+// Tab configuration - User Management only visible to admins
+const isAdmin = computed(() => user?.is_admin === true)
+
+const tabs = computed(() => {
+  const baseTabs = [
+    { label: 'General Information', icon: 'pi pi-info-circle' },
+    { label: 'Business Hours', icon: 'pi pi-clock' },
+    { label: 'Menu', icon: 'pi pi-list' },
+    { label: 'Compliance & Documents', icon: 'pi pi-file-pdf' },
+    { label: 'Financials & Payment Settings', icon: 'pi pi-credit-card' },
+  ]
+  if (isAdmin.value) {
+    baseTabs.push({ label: 'User Management', icon: 'pi pi-users' })
+  }
+  return baseTabs
+})
 
 onMounted(async () => {
   await sdkInit()

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -129,6 +129,12 @@ const userStore = useUserStore()
 const confirmed = async (userId: string) => {
   try {
     await userStore.loadUser(userId)
+
+    // Mark user as registered on first sign-in
+    const loadedUser = userStore.getUser
+    if (loadedUser && !loadedUser.registered) {
+      await userStore.updateUser(userId, { registered: true })
+    }
     
     // Redirect to user dashboard
     await redirectToUserDashboard()

--- a/pages/reset-password.vue
+++ b/pages/reset-password.vue
@@ -256,12 +256,21 @@ const resetPassword = async () => {
       throw updateError
     }
 
+    // Mark user as registered after password setup (handles invite flow)
+    const userStore = useUserStore()
+    if (user.value?.id) {
+      try {
+        await userStore.updateUser(user.value.id, { registered: true })
+      } catch (regErr) {
+        console.error('Failed to mark user as registered:', regErr)
+      }
+    }
+
     // Success - sign out the user (they were auto-logged in during password reset)
     // This ensures they need to log in with their new password
     await supabase.auth.signOut()
     
     // Clear any user store data
-    const userStore = useUserStore()
     userStore.clearUser()
 
     // Redirect to login with success message

--- a/server/api/invite-user.ts
+++ b/server/api/invite-user.ts
@@ -1,0 +1,107 @@
+import { serverSupabaseServiceRole } from '#supabase/server'
+import { Resend } from 'resend'
+
+const resend = new Resend(process.env.RESEND_API_KEY)
+
+export default defineEventHandler(async (event) => {
+  try {
+    const client = await serverSupabaseServiceRole(event)
+    const body = await readBody(event)
+
+    const { email, firstName, lastName, phone, isAdmin, availableToContact, type, associatedMerchantId, associatedVendorId, businessName } = body
+
+    if (!email) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: 'Email is required'
+      })
+    }
+
+    if (!type) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: 'User type is required'
+      })
+    }
+
+    // Create auth user via Supabase admin API with invite
+    const { data: authData, error: authError } = await client.auth.admin.inviteUserByEmail(email, {
+      data: {
+        first_name: firstName,
+        last_name: lastName
+      }
+    })
+
+    if (authError) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: authError.message || 'Failed to create auth user'
+      })
+    }
+
+    if (!authData?.user) {
+      throw createError({
+        statusCode: 500,
+        statusMessage: 'Auth user was not created'
+      })
+    }
+
+    // Create user record in our database
+    const { data: userData, error: dbError } = await client
+      .from('users')
+      .insert({
+        id: authData.user.id,
+        email,
+        first_name: firstName || null,
+        last_name: lastName || null,
+        phone: phone || null,
+        is_admin: isAdmin || false,
+        available_to_contact: availableToContact ?? true,
+        type,
+        associated_merchant_id: associatedMerchantId || null,
+        associated_vendor_id: associatedVendorId || null,
+        registered: false,
+        created_at: new Date().toISOString()
+      })
+      .select()
+      .single()
+
+    if (dbError) {
+      // Clean up auth user if db insert fails
+      await client.auth.admin.deleteUser(authData.user.id)
+      throw createError({
+        statusCode: 500,
+        statusMessage: dbError.message || 'Failed to create user record'
+      })
+    }
+
+    // Send invite email via Resend
+    try {
+      await resend.emails.send({
+        from: 'DropBy Support <noreply@dropby.com>',
+        to: [email],
+        subject: `You've been invited to join ${businessName || 'a business'} on DropBy`,
+        html: `
+          <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+            <h2>Welcome to DropBy!</h2>
+            <p>You've been invited to join <strong>${businessName || 'a business'}</strong> on DropBy.</p>
+            <p>Please check your email for a separate message with a link to set up your password and complete your account registration.</p>
+            <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #eee; font-size: 12px; color: #666;">
+              <p>This is an automated message from DropBy. Please do not reply to this email.</p>
+            </div>
+          </div>
+        `
+      })
+    } catch (emailError) {
+      console.error('Failed to send invite email:', emailError)
+    }
+
+    return { success: true, user: userData }
+  } catch (error: any) {
+    console.error('Invite user error:', error)
+    throw createError({
+      statusCode: error.statusCode || 500,
+      statusMessage: error.statusMessage || error.message || 'Failed to invite user'
+    })
+  }
+})

--- a/server/api/invite-user.ts
+++ b/server/api/invite-user.ts
@@ -25,11 +25,15 @@ export default defineEventHandler(async (event) => {
     }
 
     // Create auth user via Supabase admin API with invite
+    const siteUrl = process.env.NUXT_PUBLIC_SITE_URL || 'https://dropby.dev'
+    const redirectTo = `${siteUrl}/reset-password`
+
     const { data: authData, error: authError } = await client.auth.admin.inviteUserByEmail(email, {
       data: {
         first_name: firstName,
         last_name: lastName
-      }
+      },
+      redirectTo
     })
 
     if (authError) {

--- a/stores/user.ts
+++ b/stores/user.ts
@@ -86,6 +86,38 @@ export const useUserStore = defineStore('user', {
       }
     },
 
+    async inviteUser(inviteData: {
+      email: string
+      firstName?: string
+      lastName?: string
+      phone?: string
+      isAdmin?: boolean
+      availableToContact?: boolean
+      type: string
+      associatedMerchantId?: string | null
+      associatedVendorId?: string | null
+      businessName?: string
+    }) {
+      this.loading = true
+      try {
+        const data = await $fetch('/api/invite-user', {
+          method: 'POST',
+          body: inviteData
+        })
+
+        if (data.user) {
+          this.users.push(data.user)
+        }
+
+        return data
+      } catch (error) {
+        console.error('Error inviting user:', error)
+        throw error
+      } finally {
+        this.loading = false
+      }
+    },
+
     async updateUser(userId: string, updates: Partial<User>) {
       this.updating = true
       try {

--- a/types/index.ts
+++ b/types/index.ts
@@ -186,6 +186,7 @@ export interface User {
   updated_at: string | null
   stripe_customer_id: string | null
   current_plan: 'free' | 'pro' | 'premium'
+  registered: boolean
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Implements the admin user invitation and management flow as described in #41.

## Changes

### Admin-gated User Management Tab
- **`components/merchant/Settings.vue`** & **`components/vendor/Settings.vue`**: The "User Management" tab is now only visible to admin users (`is_admin === true`). Tabs are computed dynamically based on admin status.

### Invite User Flow
- **`components/AssociatedUsers.vue`**: Replaced the old `addUser` (client-side only) flow with a new `inviteUser` flow that calls the server endpoint. Added email validation, loading state, a `businessName` prop for the invite email, a "Status" column showing Active/Invited tags based on the `registered` field, and disabled email editing in edit mode.
- **`stores/user.ts`**: Added `inviteUser` action that POSTs to `/api/invite-user` and updates local state.

### Server Endpoint
- **`server/api/invite-user.ts`** (new): Creates a Supabase auth user via `inviteUserByEmail`, inserts a corresponding record in the `users` table with `registered: false`, and sends a welcome email via Resend. Includes cleanup (deletes auth user) if DB insert fails.

### Registration Tracking
- **`types/index.ts`**: Added `registered: boolean` field to the `User` interface.
- **`pages/login.vue`**: On first sign-in, marks the user as `registered: true`.
- **`pages/reset-password.vue`**: After password setup (invite flow), marks the user as `registered: true`.

## Testing
- Verified all changes stay within file/line limits (8 files, ~308 lines changed)
- Reviewed that admin gating logic correctly hides the tab for non-admin users
- Confirmed the invite flow validates required fields before submission
- Verified server endpoint handles errors gracefully with auth user cleanup on DB failure

Closes #41

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a new server-side invite endpoint that creates Supabase auth users via service role and sends emails, plus new `registered` state that is updated on login/reset; mistakes here can impact account provisioning and user access. Also changes settings navigation/tab visibility based on admin status, which could affect who can manage users.
> 
> **Overview**
> Adds an **admin-only user invitation flow** for merchants/vendors: Settings now hides the *User Management* tab for non-admins and passes business name into the user management view.
> 
> Replaces client-side user creation in `AssociatedUsers.vue` with an *Invite User* flow that calls a new `POST /api/invite-user`, shows invite/active status via a new `registered` field, and prevents editing email on existing users.
> 
> Introduces `server/api/invite-user.ts` to create Supabase auth invites, insert a `users` row with `registered: false` (with auth cleanup on DB failure), and send an invite email via Resend; `pages/login.vue` and `pages/reset-password.vue` now mark users as `registered: true` on first sign-in/password setup, and `stores/user.ts` adds an `inviteUser` action to call the endpoint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a06c9e1504f327649605b4aa7e0346911693884d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->