### PR TITLE
Disable calendar day if event already scheduled

### DIFF
--- a/components/event/Calendar.vue
+++ b/components/event/Calendar.vue
@@ -421,9 +421,9 @@
       @payment-dialog-closed="handlePaymentDialogClosed"
     />
 
-    <!-- Event Create Dialog - Only show for merchants if there's NO event and day is not in the past -->
+    <!-- Event Create Dialog - Only show for merchants if there's NO event, day is not in the past, and no booked event on that day -->
     <EventCreate 
-      v-if="userType === 'merchant' && merchant && !eventOnDay && dayDate && new Date(dayDate) >= new Date(new Date().setHours(0,0,0,0))"
+      v-if="userType === 'merchant' && merchant && !eventOnDay && dayDate && new Date(dayDate) >= new Date(new Date().setHours(0,0,0,0)) && !dayHasBookedEvent"
       :visible="dayViewDialog"
       @update:visible="dayViewDialog = $event"
       :merchant="merchant"
@@ -517,6 +517,11 @@ export default {
     const dayDate       = ref()
     const eventOnDay    = ref()
     const loadingRequest = ref<string | null>(null)
+
+    const dayHasBookedEvent = computed(() => {
+      if (!dayDate.value) return false
+      return hasScheduledEvent(new Date(dayDate.value))
+    })
 
     const errType       = ref()
     const errMsg        = ref()
@@ -682,6 +687,45 @@ export default {
       const dayEvents = events.value.filter((e: any) => 
         new Date(e.start).toDateString() === new Date(arg.date).toDateString()
       )
+
+      const bookedOnDay = dayEvents.some((e: any) => e.status === 'booked' || e.status === 'completed')
+
+      if (bookedOnDay && props.userType === 'merchant' && dayEvents.length > 0) {
+        // Merchant can still view existing events, but not create new ones
+        if (dayEvents.length >= 3) {
+          eventsOnDay.value = dayEvents.sort((a: any, b: any) => 
+            new Date(a.start).getTime() - new Date(b.start).getTime()
+          )
+          multipleEventsDialog.value = true
+          dayViewDialog.value = false
+          return
+        }
+        eventOnDay.value = dayEvents[0]
+        eventsOnDay.value = []
+        multipleEventsDialog.value = false
+        dayViewDialog.value = true
+        return
+      }
+
+      if (bookedOnDay && props.userType === 'vendor') {
+        showToast('info', 'Day Unavailable', 'This day already has a scheduled event.')
+        if (dayEvents.length >= 3) {
+          eventsOnDay.value = dayEvents.sort((a: any, b: any) => 
+            new Date(a.start).getTime() - new Date(b.start).getTime()
+          )
+          multipleEventsDialog.value = true
+          dayViewDialog.value = false
+          return
+        }
+        if (dayEvents.length > 0) {
+          eventOnDay.value = dayEvents[0]
+          eventsOnDay.value = []
+          multipleEventsDialog.value = false
+          dayViewDialog.value = true
+          return
+        }
+        return
+      }
       
       if (dayEvents.length >= 3) {
         // Show multiple events dialog
@@ -745,6 +789,16 @@ export default {
       refresh.value++
     }
 
+    const hasScheduledEvent = (date: Date): boolean => {
+      const dateStr = date.toDateString()
+      return events.value.some((e: any) => {
+        if (e.status === 'booked' || e.status === 'completed') {
+          return new Date(e.start).toDateString() === dateStr
+        }
+        return false
+      })
+    }
+
     // Calendar options
     const calendarOptions = computed(() => {
       console.log('Calendar options computed, events:', fullCalendarEvents.value.length)
@@ -760,18 +814,22 @@ export default {
         dateClick: handleDateClick,
         eventClick: handleEventClick,
         height: 'auto',
-        dayMaxEvents: 2, // Show max 2 events, then show summary for 3+
+        dayMaxEvents: 2,
         moreLinkClick: 'popover',
         eventDisplay: 'block',
         displayEventTime: false,
         displayEventEnd: false,
         dayCellClassNames: (arg: any) => {
+          const classes: string[] = []
           const today = new Date()
           const cellDate = new Date(arg.date)
           if (cellDate.toDateString() === today.toDateString()) {
-            return ['today-highlight']
+            classes.push('today-highlight')
           }
-          return []
+          if (hasScheduledEvent(cellDate)) {
+            classes.push('day-has-event')
+          }
+          return classes
         }
       }
     })
@@ -1153,6 +1211,7 @@ export default {
       dayId,
       getMerchantProp,
       dayDate,
+      dayHasBookedEvent,
       eventOnDay,
       errType,
       errMsg,
@@ -1274,6 +1333,29 @@ export default {
   background-color: #9ca3af;
   border-color: #9ca3af;
   opacity: 0.8;
+}
+
+:deep(.day-has-event) {
+  background-color: rgba(from var(--p-primary-color) r g b / 0.06) !important;
+  position: relative;
+}
+
+:deep(.day-has-event .fc-daygrid-day-number) {
+  opacity: 0.5;
+  text-decoration: line-through;
+}
+
+:deep(.day-has-event::after) {
+  content: '';
+  position: absolute;
+  bottom: 4px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: var(--p-primary-color);
+  opacity: 0.6;
 }
 
 .event-list-item {


### PR DESCRIPTION
## Summary
- Adds visual and functional disabling of calendar days that already have a booked or completed event
- Prevents merchants from creating new events on days with existing booked events
- Shows vendors an informational toast when clicking a day with a scheduled event
- Adds `day-has-event` CSS class with dimmed day number, strikethrough, tinted background, and dot indicator

## Changes
- **`components/event/Calendar.vue`**:
  - Added `hasScheduledEvent()` helper that checks if any event with status `booked` or `completed` exists on a given date
  - Updated `dayCellClassNames` callback to apply `day-has-event` class to days with scheduled events
  - Added `dayHasBookedEvent` computed property to gate the `EventCreate` dialog
  - Updated `handleDateClick` to show existing events (view-only) instead of the create dialog when a booked event exists on the selected day
  - For vendors, displays an informational toast ("Day Unavailable") while still allowing them to view the event details
  - Added CSS styles for `.day-has-event`: subtle background tint, reduced opacity + strikethrough on day number, and a small dot indicator

## Testing
- Verified the template, script logic, computed properties, and CSS are all consistent and correctly wired
- No breaking changes to existing event viewing, creation, or request flows

Closes #43

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only gating and styling changes in the calendar; risk is limited to potential edge cases in date/status checks affecting when dialogs/toasts appear.
> 
> **Overview**
> Prevents creating new merchant events on days that already have a *scheduled* event (`booked`/`completed`) and adds a visual indicator for those days.
> 
> Calendar day clicks now treat scheduled days specially: merchants can still open/view existing events (including the 3+ events dialog) but won’t be routed into creation, while vendors get an informational toast and can still view details. A new `day-has-event` day cell class (via `hasScheduledEvent`) dims/strikes the day number and adds a subtle highlight/dot.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0a013737379eaf07621cad7d5f4eae67a158cee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->