### PR TITLE
Fix delete user button and add Supabase auth deletion

### DIFF
--- a/components/AssociatedUsers.vue
+++ b/components/AssociatedUsers.vue
@@ -89,7 +89,7 @@
             </div>
         </Dialog>
 
-        <DeleteDialog v-if="deleteDialog" :itemType="'user'" @deleteConfirm="confirmDelete" @deleteCancel="cancelDelete" />
+        <DeleteDialog :visible="deleteDialog" :itemType="'user'" @deleteConfirm="confirmDelete" @deleteCancel="cancelDelete" />
         <ErrorDialog v-if="errDialog" :errType="errType" :errMsg="errMsg" @errorClose="errDialog = false" />
 
         <Toast ref="toast" />

--- a/components/AssociatedUsers.vue
+++ b/components/AssociatedUsers.vue
@@ -42,7 +42,15 @@
             <Column field="actions">
                 <template #body="{ data }">
                     <Button icon="pi pi-pencil" outlined rounded class="mr-2" @click="openEditDialog(data)" />
-                    <Button icon="pi pi-trash" outlined rounded severity="danger" @click="promptDeletion(data)" />
+                    <Button
+                        icon="pi pi-trash"
+                        outlined
+                        rounded
+                        severity="danger"
+                        :disabled="!canDeleteUser(data)"
+                        :title="deleteDisabledReason(data)"
+                        @click="promptDeletion(data)"
+                    />
                 </template>
             </Column>
         </DataTable>
@@ -89,7 +97,7 @@
             </div>
         </Dialog>
 
-        <DeleteDialog :visible="deleteDialog" :itemType="'user'" @deleteConfirm="confirmDelete" @deleteCancel="cancelDelete" />
+        <DeleteDialog :visible="deleteDialog" :itemType="'user'" :loading="deleteLoading" @deleteConfirm="confirmDelete" @deleteCancel="cancelDelete" />
         <ErrorDialog v-if="errDialog" :errType="errType" :errMsg="errMsg" @errorClose="errDialog = false" />
 
         <Toast ref="toast" />
@@ -97,14 +105,33 @@
 </template>
 
 <script setup lang="ts">
+import { useToast } from '~/composables/useToast'
+
 const props = defineProps<{ businessName?: string }>()
 
 const store           = useUserStore()
+const { showToast }   = useToast()
 const user: any       = store.getUser
 const assocId         = user[`associated_${user.type}_id`]
 const associatedUsers = computed(() =>
     store.getAllUsers.filter((u: any) => u[`associated_${user.type}_id`] === assocId)
 )
+const adminCount = computed(() => associatedUsers.value.filter((u: any) => u.is_admin).length)
+
+/** Disable delete for: own account, or last admin in the business */
+const canDeleteUser = (row: any) => {
+    if (!row || !user) return false
+    if (row.id === user.id) return false
+    if (row.is_admin && adminCount.value <= 1) return false
+    return true
+}
+const deleteDisabledReason = (row: any) => {
+    if (!row || !user) return ''
+    if (row.id === user.id) return "You cannot delete your own account"
+    if (row.is_admin && adminCount.value <= 1) return "Cannot remove the only admin user"
+    return ''
+}
+
 const openDialog      = ref(false)
 const headerTitle     = ref('')
 const loading         = ref(false)
@@ -112,6 +139,7 @@ const snackbar        = ref(false)
 const snacktext       = ref('')
 const userToDelete    = ref<any>(null)
 const deleteDialog    = ref(false)
+const deleteLoading   = ref(false)
 const editId          = ref('')
 
 const first           = ref('')
@@ -220,15 +248,20 @@ const resetFields = () => {
     phone.value = ''
 }
 const promptDeletion = (item: any) => {
+    if (!canDeleteUser(item)) return
     userToDelete.value = item
     deleteDialog.value = true
 }
 const confirmDelete = async () => {
+    if (!userToDelete.value || !canDeleteUser(userToDelete.value)) {
+        deleteDialog.value = false
+        userToDelete.value = null
+        return
+    }
+    deleteLoading.value = true
     try {
         await store.deleteUser(userToDelete.value.id)
-        snackbar.value = true
-        snacktext.value = 'User deleted.'
-
+        showToast('success', 'User Deleted', 'The user has been removed successfully.', 5000)
         refreshUsers()
         deleteDialog.value = false
         userToDelete.value = null
@@ -236,6 +269,8 @@ const confirmDelete = async () => {
         errType.value = 'User Deletion'
         errMsg.value = error.message || 'Failed to delete user'
         errDialog.value = true
+    } finally {
+        deleteLoading.value = false
     }
 }
 const cancelDelete = () => {

--- a/components/DeleteDialog.vue
+++ b/components/DeleteDialog.vue
@@ -26,6 +26,7 @@
                 label="Cancel" 
                 severity="secondary" 
                 outlined
+                :disabled="loading"
                 @click="deleteCancel"
                 class="min-w-[80px]"
             />
@@ -33,6 +34,8 @@
                 type="button" 
                 label="Delete" 
                 severity="danger" 
+                :loading="loading"
+                :disabled="loading"
                 @click="deleteConfirm"
                 class="min-w-[80px]"
             />
@@ -44,9 +47,10 @@
 interface Props {
     visible: boolean
     itemType: string
+    loading?: boolean
 }
 
-const props = defineProps<Props>()
+const props = withDefaults(defineProps<Props>(), { loading: false })
 const emit = defineEmits(['deleteCancel', 'deleteConfirm'])
 
 const deleteCancel = () => emit('deleteCancel')

--- a/server/api/delete-user.ts
+++ b/server/api/delete-user.ts
@@ -1,0 +1,49 @@
+import { serverSupabaseServiceRole } from '#supabase/server'
+
+export default defineEventHandler(async (event) => {
+  try {
+    const client = await serverSupabaseServiceRole(event)
+    const body = await readBody(event)
+
+    const { userId } = body
+
+    if (!userId) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: 'User ID is required'
+      })
+    }
+
+    // Delete user from the users database table first
+    const { error: dbError } = await client
+      .from('users')
+      .delete()
+      .eq('id', userId)
+
+    if (dbError) {
+      throw createError({
+        statusCode: 500,
+        statusMessage: dbError.message || 'Failed to delete user record from database'
+      })
+    }
+
+    // Delete user from Supabase Authentication
+    const { error: authError } = await client.auth.admin.deleteUser(userId)
+
+    if (authError) {
+      console.error('Failed to delete auth user (DB record already removed):', authError)
+      throw createError({
+        statusCode: 500,
+        statusMessage: authError.message || 'Failed to delete user from authentication'
+      })
+    }
+
+    return { success: true }
+  } catch (error: any) {
+    console.error('Delete user error:', error)
+    throw createError({
+      statusCode: error.statusCode || 500,
+      statusMessage: error.statusMessage || error.message || 'Failed to delete user'
+    })
+  }
+})

--- a/server/api/delete-user.ts
+++ b/server/api/delete-user.ts
@@ -14,7 +14,7 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    // Delete user from the users database table first
+    // 1. Delete from public.users if row exists (RLS-safe; service role sees all)
     const { error: dbError } = await client
       .from('users')
       .delete()
@@ -27,11 +27,16 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    // Delete user from Supabase Authentication
+    // 2. Delete from Supabase Auth if the auth user exists (e.g. invited but not yet signed in)
     const { error: authError } = await client.auth.admin.deleteUser(userId)
 
     if (authError) {
-      console.error('Failed to delete auth user (DB record already removed):', authError)
+      const isNotFound = /user not found|not found/i.test(authError.message || '')
+      if (isNotFound) {
+        // Auth user already gone or never existed (e.g. invited user) – not a failure
+        return { success: true }
+      }
+      console.error('Failed to delete auth user:', authError)
       throw createError({
         statusCode: 500,
         statusMessage: authError.message || 'Failed to delete user from authentication'
@@ -40,6 +45,7 @@ export default defineEventHandler(async (event) => {
 
     return { success: true }
   } catch (error: any) {
+    if (error.statusCode && error.statusCode !== 500) throw error
     console.error('Delete user error:', error)
     throw createError({
       statusCode: error.statusCode || 500,

--- a/stores/user.ts
+++ b/stores/user.ts
@@ -162,14 +162,10 @@ export const useUserStore = defineStore('user', {
 
     async deleteUser(userId: string) {
       try {
-        const supabase = useSupabaseClient()
-        
-        const { error } = await supabase
-          .from('users')
-          .delete()
-          .eq('id', userId)
-
-        if (error) throw error
+        await $fetch('/api/delete-user', {
+          method: 'POST',
+          body: { userId }
+        })
 
         // Remove from local state
         this.users = this.users.filter(user => user.id !== userId)


### PR DESCRIPTION
## Summary
- Fixed the delete button in the User Management tab that was non-functional
- Added server-side endpoint to properly delete users from both Supabase Authentication and the users database

## Changes

### Bug Fix: DeleteDialog not showing (`components/AssociatedUsers.vue`)
The `DeleteDialog` component was conditionally rendered with `v-if` but its required `:visible` prop was never passed, causing the PrimeVue Dialog inside it to remain hidden. Changed from `v-if="deleteDialog"` to `:visible="deleteDialog"` so the dialog actually displays when the delete button is clicked.

### New: Server-side delete user endpoint (`server/api/delete-user.ts`)
Created a new API endpoint that uses the Supabase service role client to:
1. Delete the user record from the `users` database table
2. Delete the user from Supabase Authentication via `auth.admin.deleteUser()`

This requires the service role key (server-side only) since client-side Supabase cannot delete auth users.

### Updated: User store delete action (`stores/user.ts`)
Updated `deleteUser()` to call the new `/api/delete-user` server endpoint via `$fetch` instead of directly deleting from the database. This ensures both the database record and the Supabase auth user are removed.

## Test Plan
- [ ] Navigate to Settings > User Management tab as an admin user
- [ ] Click the delete (trash) button on a user row
- [ ] Verify the DeleteDialog confirmation prompt appears
- [ ] Click Cancel and verify the dialog closes without deleting
- [ ] Click Delete and verify the user is removed from the table
- [ ] Verify the user is removed from both the `users` table and Supabase Authentication

Closes #45