### PR TITLE
Add superadmin identity and route protection for /admin

### DIFF
--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -4,7 +4,7 @@
     <Menubar v-if="isAuthenticated" :model="authenticatedMenuItems" class="app-header-authenticated">
       <template #start>
         <NuxtLink
-          :to="`/${currentUser?.type}/${currentUser?.type === 'vendor' ? currentUser?.associated_vendor_id : currentUser?.associated_merchant_id}/dashboard`"
+          :to="isSuperadmin ? '/admin' : `/${currentUser?.type}/${currentUser?.type === 'vendor' ? currentUser?.associated_vendor_id : currentUser?.associated_merchant_id}/dashboard`"
           class="m-2 text-xl font-bold text-primary"
         >
         <Logo class="w-10 h-10 font-bold" :fontControlled="false" style="color: var(--primary-color);" />
@@ -144,7 +144,7 @@ defineEmits(['create-event'])
 
 const router = useRouter()
 const route = useRoute()
-const { isAuthenticated, currentUser, signOut } = useAuth()
+const { isAuthenticated, currentUser, isSuperadmin, signOut } = useAuth()
 const { isDark, toggleTheme } = useTheme()
 const renderKey = ref(0)
 
@@ -245,9 +245,33 @@ const userAssociatedId = computed(() => {
   return currentUser.value[associatedIdKey.value] as string | null
 })
 
-// Profile menu items - different for merchants and vendors
+// Profile menu items - different for merchants, vendors, and superadmin
 const profileMenuItems = computed(() => {
+  // Superadmin (no type/associated id): only theme toggle and sign out
   if (!businessType.value || !userAssociatedId.value) {
+    if (isSuperadmin.value) {
+      return [
+        {
+          label: 'Admin',
+          icon: 'pi pi-shield',
+          command: () => router.push('/admin')
+        },
+        { separator: true },
+        {
+          label: `${isDark.value ? 'Light Mode' : 'Dark Mode'}`,
+          icon: `${isDark.value ? 'pi pi-sun' : 'pi pi-moon'}`,
+          command: () => {
+            toggleTheme()
+            renderKey.value++
+          }
+        },
+        {
+          label: 'Sign out',
+          icon: 'pi pi-sign-out',
+          command: async () => await handleSignOut()
+        }
+      ]
+    }
     return []
   }
 

--- a/composables/useAuth.ts
+++ b/composables/useAuth.ts
@@ -74,6 +74,10 @@ export const useAuth = () => {
 
     const currentUserData = currentUser.value
     if (!currentUserData?.type) {
+      if (userStore.isSuperadmin) {
+        await router.push('/admin')
+        return
+      }
       await router.push('/get-started')
       return
     }

--- a/composables/useAuth.ts
+++ b/composables/useAuth.ts
@@ -21,6 +21,11 @@ export const useAuth = () => {
     return userStore.userType
   })
 
+  // Check if user is superadmin
+  const isSuperadmin = computed(() => {
+    return userStore.isSuperadmin
+  })
+
   // Sign out user
   const signOut = async () => {
     try {
@@ -104,6 +109,7 @@ export const useAuth = () => {
     isAuthenticated,
     currentUser,
     userType,
+    isSuperadmin,
     signOut,
     canAccess,
     redirectToUserDashboard

--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -49,8 +49,11 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
         }
     }
 
-    // If user exists but has no type, redirect to onboarding
+    // If user exists but has no type, redirect to onboarding (except when going to /admin — superadmin may have type null)
     if (user.value && storeUser && !storeUser.type) {
+        if (to.path === '/admin') {
+            return // Let superadmin middleware handle access
+        }
         return navigateTo('/get-started')
     }
 

--- a/middleware/superadmin.ts
+++ b/middleware/superadmin.ts
@@ -1,0 +1,12 @@
+export default defineNuxtRouteMiddleware(async (_to, _from) => {
+  const store = useUserStore()
+  const user = store.getUser
+
+  if (!user) {
+    return navigateTo('/')
+  }
+
+  if (user.is_superadmin !== true) {
+    return navigateTo('/')
+  }
+})

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -33,6 +33,7 @@ export default defineNuxtConfig({
     "@nuxt/image"
   ],
   runtimeConfig: {
+    superadminEmail: process.env.SUPERADMIN_EMAIL || '',
     public: {
       autocomplete: process.env.GEO_KEY,
       gMapKey: process.env.GMAPS_API_KEY,

--- a/pages/admin.vue
+++ b/pages/admin.vue
@@ -35,7 +35,7 @@
 
 <script setup lang="ts">
 definePageMeta({
-    middleware: ['auth']
+    middleware: ['auth', 'superadmin']
 })
 
 // Set page title

--- a/server/utils/superadmin.ts
+++ b/server/utils/superadmin.ts
@@ -1,0 +1,39 @@
+import { serverSupabaseUser, serverSupabaseServiceRole } from '#supabase/server'
+import type { H3Event } from 'h3'
+
+/**
+ * Resolves whether the current request is from a superadmin.
+ * Checks the `is_superadmin` column first (Option A), then falls
+ * back to comparing the session email against SUPERADMIN_EMAIL (Option B).
+ * Throws a 403 error if the user is not a superadmin.
+ */
+export async function requireSuperadmin(event: H3Event): Promise<void> {
+  const user = await serverSupabaseUser(event)
+
+  if (!user) {
+    throw createError({ statusCode: 401, statusMessage: 'Authentication required' })
+  }
+
+  const client = await serverSupabaseServiceRole(event)
+
+  const { data, error } = await client
+    .from('users')
+    .select('is_superadmin, email')
+    .eq('id', user.id)
+    .single()
+
+  if (error || !data) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden' })
+  }
+
+  if (data.is_superadmin === true) {
+    return
+  }
+
+  const config = useRuntimeConfig()
+  if (config.superadminEmail && data.email === config.superadminEmail) {
+    return
+  }
+
+  throw createError({ statusCode: 403, statusMessage: 'Forbidden – superadmin access required' })
+}

--- a/stores/user.ts
+++ b/stores/user.ts
@@ -23,6 +23,8 @@ export const useUserStore = defineStore('user', {
       return state.users.filter(user => user.type === userType)
     },
     
+    isSuperadmin: (state): boolean => state.user?.is_superadmin === true,
+
     getAdminUsers: (state) => {
       return state.users.filter(user => user.is_admin)
     },

--- a/types/index.ts
+++ b/types/index.ts
@@ -174,6 +174,7 @@ export interface User {
   id: string
   created_at: string
   is_admin: boolean
+  is_superadmin?: boolean
   first_name: string | null
   last_name: string | null
   phone: string | null


### PR DESCRIPTION
## Summary

Implements superadmin identity and route protection as described in #47. Only the founder (superadmin) can now access the internal `/admin` page.

## Changes

### Types
- Added `is_superadmin?: boolean` to the `User` interface in `types/index.ts` (Option A – DB column approach)

### Client-side middleware
- Created `middleware/superadmin.ts` – runs after the `auth` middleware and redirects non-superadmin users to the home page
- Updated `pages/admin.vue` to use `middleware: ['auth', 'superadmin']`

### Server-side utility
- Created `server/utils/superadmin.ts` with a `requireSuperadmin(event)` helper that:
  - Checks the `is_superadmin` column on the `users` table (Option A)
  - Falls back to comparing the session user's email against the `SUPERADMIN_EMAIL` env var (Option B)
  - Throws 401/403 errors for unauthenticated or unauthorized requests
  - Can be called from any server API handler to protect admin-only endpoints

### Runtime config
- Added `superadminEmail` (server-only) to `nuxt.config.ts` `runtimeConfig`, sourced from `SUPERADMIN_EMAIL` env var

### Store & composable
- Added `isSuperadmin` getter to the user Pinia store
- Added `isSuperadmin` computed property to the `useAuth` composable

## Setup required

1. Add `is_superadmin boolean default false` column to the `users` table in Supabase
2. Set `is_superadmin = true` for the founder's account
3. Optionally set `SUPERADMIN_EMAIL` env var as a fallback

## Testing

- `nuxi build` passes successfully with no TypeScript or compilation errors

Closes #47