### PR TITLE
Send email to review recipient after new review creation

### DIFF
--- a/server/api/sendReviewNotification.ts
+++ b/server/api/sendReviewNotification.ts
@@ -6,28 +6,29 @@ const resend = new Resend(process.env.RESEND_API_KEY)
 export default defineEventHandler(async (event) => {
     try {
         const client = await serverSupabaseClient(event)
-        const query = getQuery(event)
+        const body = await readBody(event)
 
-        if (!query.recipientId || !query.senderId || !query.rating) {
+        const { recipientId, senderId, rating, content: reviewContent } = body
+
+        if (!recipientId || !senderId || !rating) {
             throw createError({
                 statusCode: 400,
                 statusMessage: 'Missing required parameters: recipientId, senderId, rating'
             })
         }
 
-        const rating = Number(query.rating)
+        const numericRating = Number(rating)
 
-        // Determine if sender/recipient are merchants or vendors
         const [
             { data: senderMerchant },
             { data: senderVendor },
             { data: recipientMerchant },
             { data: recipientVendor }
         ] = await Promise.all([
-            client.from('merchants').select('id, merchant_name').eq('id', query.senderId).maybeSingle(),
-            client.from('vendors').select('id, vendor_name').eq('id', query.senderId).maybeSingle(),
-            client.from('merchants').select('id, merchant_name').eq('id', query.recipientId).maybeSingle(),
-            client.from('vendors').select('id, vendor_name').eq('id', query.recipientId).maybeSingle()
+            client.from('merchants').select('id, merchant_name').eq('id', senderId).maybeSingle(),
+            client.from('vendors').select('id, vendor_name').eq('id', senderId).maybeSingle(),
+            client.from('merchants').select('id, merchant_name').eq('id', recipientId).maybeSingle(),
+            client.from('vendors').select('id, vendor_name').eq('id', recipientId).maybeSingle()
         ])
 
         const senderName = senderMerchant?.merchant_name || senderVendor?.vendor_name || 'A business'
@@ -38,10 +39,10 @@ export default defineEventHandler(async (event) => {
             ? 'associated_merchant_id'
             : 'associated_vendor_id'
 
-        const starLabel = rating === 1 ? 'star' : 'stars'
-        const starsHtml = '★'.repeat(rating) + '☆'.repeat(5 - rating)
+        const starLabel = numericRating === 1 ? 'star' : 'stars'
+        const starsHtml = '★'.repeat(numericRating) + '☆'.repeat(5 - numericRating)
 
-        const content = `
+        const emailHtml = `
             <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
                 <h2 style="color: #4f46e5;">⭐ New Review Received!</h2>
                 <p><strong>${senderName}</strong> has left a review for <strong>${recipientName}</strong>.</p>
@@ -49,8 +50,8 @@ export default defineEventHandler(async (event) => {
                 <div style="background-color: #f8f9fa; padding: 20px; border-radius: 8px; margin: 20px 0;">
                     <h3 style="margin-top: 0;">Review Details</h3>
                     <p style="font-size: 24px; color: #f59e0b; margin: 8px 0;">${starsHtml}</p>
-                    <p><strong>Rating:</strong> ${rating} ${starLabel} out of 5</p>
-                    ${query.content ? `<p><strong>Review:</strong> "${query.content}"</p>` : ''}
+                    <p><strong>Rating:</strong> ${numericRating} ${starLabel} out of 5</p>
+                    ${reviewContent ? `<p><strong>Review:</strong> "${reviewContent}"</p>` : ''}
                 </div>
                 
                 <p>Log into your DropBy dashboard to view the full review and respond.</p>
@@ -61,11 +62,10 @@ export default defineEventHandler(async (event) => {
             </div>
         `
 
-        // Get all user emails for the recipient business where available_to_contact = true
         const { data: recipientUsers, error: usersError } = await client
             .from('users')
             .select('email')
-            .eq(recipientBusinessKey, query.recipientId)
+            .eq(recipientBusinessKey, recipientId)
             .eq('available_to_contact', true)
             .not('email', 'is', null)
 
@@ -92,8 +92,8 @@ export default defineEventHandler(async (event) => {
         const emailData = await resend.emails.send({
             from: 'DropBy Support <support@dropby.dev>',
             to: recipients,
-            subject: `New ${rating}-Star Review from ${senderName}`,
-            html: content,
+            subject: `New ${numericRating}-Star Review from ${senderName}`,
+            html: emailHtml,
         })
 
         return { success: true, data: emailData }

--- a/server/api/sendReviewNotification.ts
+++ b/server/api/sendReviewNotification.ts
@@ -1,0 +1,105 @@
+import { serverSupabaseClient } from '#supabase/server'
+import { Resend } from 'resend'
+
+const resend = new Resend(process.env.RESEND_API_KEY)
+
+export default defineEventHandler(async (event) => {
+    try {
+        const client = await serverSupabaseClient(event)
+        const query = getQuery(event)
+
+        if (!query.recipientId || !query.senderId || !query.rating) {
+            throw createError({
+                statusCode: 400,
+                statusMessage: 'Missing required parameters: recipientId, senderId, rating'
+            })
+        }
+
+        const rating = Number(query.rating)
+
+        // Determine if sender/recipient are merchants or vendors
+        const [
+            { data: senderMerchant },
+            { data: senderVendor },
+            { data: recipientMerchant },
+            { data: recipientVendor }
+        ] = await Promise.all([
+            client.from('merchants').select('id, merchant_name').eq('id', query.senderId).maybeSingle(),
+            client.from('vendors').select('id, vendor_name').eq('id', query.senderId).maybeSingle(),
+            client.from('merchants').select('id, merchant_name').eq('id', query.recipientId).maybeSingle(),
+            client.from('vendors').select('id, vendor_name').eq('id', query.recipientId).maybeSingle()
+        ])
+
+        const senderName = senderMerchant?.merchant_name || senderVendor?.vendor_name || 'A business'
+        const recipientName = recipientMerchant?.merchant_name || recipientVendor?.vendor_name || 'your business'
+
+        const recipientIsMerchant = !!recipientMerchant
+        const recipientBusinessKey = recipientIsMerchant
+            ? 'associated_merchant_id'
+            : 'associated_vendor_id'
+
+        const starLabel = rating === 1 ? 'star' : 'stars'
+        const starsHtml = '★'.repeat(rating) + '☆'.repeat(5 - rating)
+
+        const content = `
+            <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+                <h2 style="color: #4f46e5;">⭐ New Review Received!</h2>
+                <p><strong>${senderName}</strong> has left a review for <strong>${recipientName}</strong>.</p>
+                
+                <div style="background-color: #f8f9fa; padding: 20px; border-radius: 8px; margin: 20px 0;">
+                    <h3 style="margin-top: 0;">Review Details</h3>
+                    <p style="font-size: 24px; color: #f59e0b; margin: 8px 0;">${starsHtml}</p>
+                    <p><strong>Rating:</strong> ${rating} ${starLabel} out of 5</p>
+                    ${query.content ? `<p><strong>Review:</strong> "${query.content}"</p>` : ''}
+                </div>
+                
+                <p>Log into your DropBy dashboard to view the full review and respond.</p>
+                
+                <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #eee; font-size: 12px; color: #999;">
+                    <p>This is an automated message from DropBy. Please do not reply to this email.</p>
+                </div>
+            </div>
+        `
+
+        // Get all user emails for the recipient business where available_to_contact = true
+        const { data: recipientUsers, error: usersError } = await client
+            .from('users')
+            .select('email')
+            .eq(recipientBusinessKey, query.recipientId)
+            .eq('available_to_contact', true)
+            .not('email', 'is', null)
+
+        if (usersError) {
+            throw createError({
+                statusCode: 500,
+                statusMessage: 'Failed to fetch recipient business users'
+            })
+        }
+
+        const recipients: string[] = []
+        if (recipientUsers && recipientUsers.length > 0) {
+            recipientUsers.forEach((user: any) => {
+                if (user.email && !recipients.includes(user.email)) {
+                    recipients.push(user.email)
+                }
+            })
+        }
+
+        if (recipients.length === 0) {
+            return { success: true, skipped: true, message: 'No contactable users found for recipient business' }
+        }
+
+        const emailData = await resend.emails.send({
+            from: 'DropBy Support <support@dropby.dev>',
+            to: recipients,
+            subject: `New ${rating}-Star Review from ${senderName}`,
+            html: content,
+        })
+
+        return { success: true, data: emailData }
+
+    } catch (error: any) {
+        console.error('Review notification error:', error)
+        return { error: error.message || 'Failed to send review notification' }
+    }
+})

--- a/services/api/notificationService.ts
+++ b/services/api/notificationService.ts
@@ -1,0 +1,27 @@
+// ============================================================================
+// NOTIFICATION SERVICE
+// ============================================================================
+
+import { useApi } from '~/composables/useApi'
+
+export interface SendReviewNotificationParams {
+  recipientId: string
+  senderId: string
+  rating: number
+  content?: string
+}
+
+export interface SendReviewNotificationResponse {
+  success: boolean
+  skipped?: boolean
+  message?: string
+  data?: any
+  error?: string
+}
+
+export const notificationService = {
+  sendReviewNotification: async (params: SendReviewNotificationParams): Promise<SendReviewNotificationResponse> => {
+    const api = useApi()
+    return await api.post<SendReviewNotificationResponse>('/api/sendReviewNotification', params)
+  }
+}

--- a/stores/review.ts
+++ b/stores/review.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import type { Review } from '~/types'
+import { notificationService } from '~/services/api/notificationService'
 
 export const useReviewStore = defineStore('review', {
   state: () => ({
@@ -133,9 +134,13 @@ export const useReviewStore = defineStore('review', {
           }
         }
         
-        // Send email notification to contactable users of the recipient business
         try {
-          await $fetch(`/api/sendReviewNotification?recipientId=${data.recipient_id}&senderId=${data.sender_id}&rating=${data.rating}&content=${encodeURIComponent(data.content || '')}`)
+          await notificationService.sendReviewNotification({
+            recipientId: data.recipient_id,
+            senderId: data.sender_id,
+            rating: data.rating,
+            content: data.content || ''
+          })
         } catch (emailErr) {
           console.error('Review email notification failed:', emailErr)
         }

--- a/stores/review.ts
+++ b/stores/review.ts
@@ -133,6 +133,13 @@ export const useReviewStore = defineStore('review', {
           }
         }
         
+        // Send email notification to contactable users of the recipient business
+        try {
+          await $fetch(`/api/sendReviewNotification?recipientId=${data.recipient_id}&senderId=${data.sender_id}&rating=${data.rating}&content=${encodeURIComponent(data.content || '')}`)
+        } catch (emailErr) {
+          console.error('Review email notification failed:', emailErr)
+        }
+        
         return data
       } catch (error) {
         console.error('Error creating review:', error)


### PR DESCRIPTION
## Summary
- Sends an email notification to all associated users of the recipient business when a new review is created
- Only emails users whose `available_to_contact` is `true` and who have an email address
- Works for both merchant and vendor recipients

## Changes

### New file: `server/api/sendReviewNotification.ts`
- Server-side API endpoint following the existing email notification pattern (`sendBookingConfirmation.ts`, `sendEventRequestNotification.ts`)
- Accepts `recipientId`, `senderId`, `rating`, and optional `content` as query parameters
- Looks up sender and recipient business names (checking both merchants and vendors tables)
- Queries users associated with the recipient business where `available_to_contact = true` and email is not null
- Sends a formatted HTML email via Resend with review details (star rating, review text)
- Gracefully skips if no contactable users are found

### Modified: `stores/review.ts`
- Added a `$fetch` call to `/api/sendReviewNotification` in the `createReview` action, after the existing in-app notification logic
- Email failure is caught and logged without blocking the review creation flow

## Testing
- Verified the new endpoint follows the same patterns as existing email endpoints
- Ran `nuxi typecheck` — all errors are pre-existing and unrelated to this change

Closes #53