### PR TITLE
feat: add event reminder system with cron endpoint

### DIFF
--- a/scripts/create-event-reminders-table.sql
+++ b/scripts/create-event-reminders-table.sql
@@ -1,0 +1,25 @@
+-- Event Reminders table
+-- Tracks which reminders have been sent for each event to prevent duplicates.
+-- Reminder types: '7d' (7 days before), '1d' (1 day before), 'day_of' (day of event)
+
+CREATE TABLE IF NOT EXISTS event_reminders (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id UUID NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+  reminder_type TEXT NOT NULL CHECK (reminder_type IN ('7d', '1d', 'day_of')),
+  sent_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (event_id, reminder_type)
+);
+
+-- Enable Row Level Security
+ALTER TABLE event_reminders ENABLE ROW LEVEL SECURITY;
+
+-- Service-role policy for server-side access
+CREATE POLICY "Service role can manage event_reminders"
+  ON event_reminders
+  FOR ALL
+  USING (true)
+  WITH CHECK (true);
+
+-- Index for efficient lookups by event_id
+CREATE INDEX IF NOT EXISTS idx_event_reminders_event_id ON event_reminders(event_id);

--- a/server/api/cron/send-event-reminders.ts
+++ b/server/api/cron/send-event-reminders.ts
@@ -1,0 +1,244 @@
+import { serverSupabaseClient } from '#supabase/server'
+import { Resend } from 'resend'
+import type { ReminderType } from '~/types'
+
+const resend = new Resend(process.env.RESEND_API_KEY)
+
+interface ReminderWindow {
+  type: ReminderType
+  label: string
+  rangeStart: Date
+  rangeEnd: Date
+}
+
+function buildReminderWindows(now: Date): ReminderWindow[] {
+  const todayStart = new Date(now)
+  todayStart.setHours(0, 0, 0, 0)
+
+  const todayEnd = new Date(now)
+  todayEnd.setHours(23, 59, 59, 999)
+
+  const addDays = (date: Date, days: number) => {
+    const d = new Date(date)
+    d.setDate(d.getDate() + days)
+    return d
+  }
+
+  return [
+    {
+      type: '7d',
+      label: '7 days',
+      rangeStart: addDays(todayStart, 7),
+      rangeEnd: addDays(todayEnd, 7),
+    },
+    {
+      type: '1d',
+      label: '1 day',
+      rangeStart: addDays(todayStart, 1),
+      rangeEnd: addDays(todayEnd, 1),
+    },
+    {
+      type: 'day_of',
+      label: 'today',
+      rangeStart: todayStart,
+      rangeEnd: todayEnd,
+    },
+  ]
+}
+
+function buildReminderEmailHtml(params: {
+  reminderLabel: string
+  merchantName: string
+  vendorName: string
+  date: string
+  startTime: string
+  endTime: string
+  locationAddress: string | null
+  locationUrl: string | null
+  notes: string | null
+}): string {
+  const { reminderLabel, merchantName, vendorName, date, startTime, endTime, locationAddress, locationUrl, notes } = params
+
+  return `
+    <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+      <h2 style="color: #4f46e5;">📅 Event Reminder</h2>
+      <p>This is a friendly reminder that your event is coming up <strong>${reminderLabel}</strong> from now.</p>
+
+      <div style="background-color: #f8f9fa; padding: 20px; border-radius: 8px; margin: 20px 0;">
+        <h3 style="margin-top: 0;">Event Details</h3>
+        <p><strong>Merchant:</strong> ${merchantName}</p>
+        <p><strong>Vendor:</strong> ${vendorName}</p>
+        <p><strong>Date:</strong> ${date}</p>
+        <p><strong>Time:</strong> ${startTime} - ${endTime}</p>
+        <p><strong>Location:</strong> <a href="${locationUrl || '#'}" target="_blank">${locationAddress || 'TBD'}</a></p>
+        ${notes ? `<p><strong>Notes:</strong> ${notes}</p>` : ''}
+      </div>
+
+      <p>Please make sure everything is prepared and reach out to each other if you need to coordinate any details.</p>
+
+      <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #eee; font-size: 12px; color: #6b7280;">
+        <p>This is an automated reminder from DropBy. Please do not reply to this email.</p>
+      </div>
+    </div>
+  `
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const authHeader = getHeader(event, 'authorization')
+    const expectedToken = process.env.CRON_SECRET
+
+    if (!expectedToken || authHeader !== `Bearer ${expectedToken}`) {
+      throw createError({
+        statusCode: 401,
+        statusMessage: 'Unauthorized',
+      })
+    }
+
+    const client = await serverSupabaseClient(event)
+    const now = new Date()
+    const windows = buildReminderWindows(now)
+
+    const sentReminders: { eventId: string; reminderType: ReminderType; recipients: string[] }[] = []
+    const errors: string[] = []
+
+    for (const window of windows) {
+      try {
+        const { data: events, error: eventsError } = await client
+          .from('events')
+          .select('*')
+          .eq('status', 'booked')
+          .not('vendor', 'is', null)
+          .not('merchant', 'is', null)
+          .gte('start', window.rangeStart.toISOString())
+          .lte('start', window.rangeEnd.toISOString())
+
+        if (eventsError) {
+          errors.push(`Failed to query events for ${window.type} window: ${eventsError.message}`)
+          continue
+        }
+
+        if (!events || events.length === 0) continue
+
+        for (const eventData of events) {
+          try {
+            const { data: existingReminder } = await client
+              .from('event_reminders')
+              .select('id')
+              .eq('event_id', eventData.id)
+              .eq('reminder_type', window.type)
+              .limit(1)
+              .single()
+
+            if (existingReminder) continue
+
+            const [merchantResult, vendorResult] = await Promise.all([
+              client.from('merchants').select('merchant_name').eq('id', eventData.merchant).single(),
+              client.from('vendors').select('vendor_name').eq('id', eventData.vendor).single(),
+            ])
+
+            const merchantName = merchantResult.data?.merchant_name || 'Merchant'
+            const vendorName = vendorResult.data?.vendor_name || 'Vendor'
+
+            const recipients: string[] = []
+
+            const [merchantUsersResult, vendorUsersResult] = await Promise.all([
+              client
+                .from('users')
+                .select('email')
+                .eq('associated_merchant_id', eventData.merchant)
+                .eq('available_to_contact', true)
+                .not('email', 'is', null),
+              client
+                .from('users')
+                .select('email')
+                .eq('associated_vendor_id', eventData.vendor)
+                .eq('available_to_contact', true)
+                .not('email', 'is', null),
+            ])
+
+            if (!merchantUsersResult.error && merchantUsersResult.data) {
+              for (const user of merchantUsersResult.data) {
+                if ((user as any).email && !recipients.includes((user as any).email)) {
+                  recipients.push((user as any).email)
+                }
+              }
+            }
+
+            if (!vendorUsersResult.error && vendorUsersResult.data) {
+              for (const user of vendorUsersResult.data) {
+                if ((user as any).email && !recipients.includes((user as any).email)) {
+                  recipients.push((user as any).email)
+                }
+              }
+            }
+
+            if (recipients.length === 0) {
+              errors.push(`No contactable recipients for event ${eventData.id} (${window.type} reminder)`)
+              continue
+            }
+
+            const eventStart = new Date(eventData.start)
+            const eventEnd = new Date(eventData.end)
+
+            const html = buildReminderEmailHtml({
+              reminderLabel: window.label,
+              merchantName,
+              vendorName,
+              date: eventStart.toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }),
+              startTime: eventStart.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }),
+              endTime: eventEnd.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }),
+              locationAddress: eventData.location_address,
+              locationUrl: eventData.location_url,
+              notes: eventData.notes,
+            })
+
+            await resend.emails.send({
+              from: 'DropBy Support <support@dropby.dev>',
+              to: recipients,
+              subject: `Event Reminder: ${vendorName} at ${merchantName} — ${window.label} away`,
+              html,
+            })
+
+            const { error: insertError } = await client
+              .from('event_reminders')
+              .insert({
+                event_id: eventData.id,
+                reminder_type: window.type,
+                sent_at: new Date().toISOString(),
+              })
+
+            if (insertError) {
+              errors.push(`Failed to record reminder for event ${eventData.id} (${window.type}): ${insertError.message}`)
+            }
+
+            sentReminders.push({
+              eventId: eventData.id,
+              reminderType: window.type,
+              recipients,
+            })
+          } catch (err: any) {
+            errors.push(`Error processing event ${eventData.id} for ${window.type} reminder: ${err.message}`)
+          }
+        }
+      } catch (err: any) {
+        errors.push(`Error processing ${window.type} reminder window: ${err.message}`)
+      }
+    }
+
+    return {
+      success: true,
+      message: `Sent ${sentReminders.length} event reminders`,
+      sentCount: sentReminders.length,
+      sentReminders,
+      errors: errors.length > 0 ? errors : undefined,
+      timestamp: now.toISOString(),
+    }
+  } catch (error: any) {
+    console.error('Event reminder cron error:', error)
+    throw createError({
+      statusCode: error.statusCode || 500,
+      statusMessage: error.statusMessage || error.message || 'Failed to send event reminders',
+    })
+  }
+})

--- a/types/index.ts
+++ b/types/index.ts
@@ -331,6 +331,20 @@ export interface UserFeedback {
 }
 
 // ============================================================================
+// EVENT REMINDER TYPES
+// ============================================================================
+
+export type ReminderType = '7d' | '1d' | 'day_of'
+
+export interface EventReminder {
+  id: string
+  event_id: string
+  reminder_type: ReminderType
+  sent_at: string
+  created_at: string
+}
+
+// ============================================================================
 // COMMON TYPES
 // ============================================================================
 


### PR DESCRIPTION
## Summary

- Adds automated email reminders for booked events at three strategic intervals: 7 days before, 1 day before, and day of event
- Creates a new `event_reminders` table to track sent reminders and prevent duplicates
- Emails are sent to both merchant and vendor users who have `available_to_contact = true`

## Changes

### New Files
- **`server/api/cron/send-event-reminders.ts`** — Cron endpoint that:
  - Authenticates via `Authorization: Bearer <CRON_SECRET>` header
  - Queries booked events falling within each reminder window (7d, 1d, day_of)
  - Checks the `event_reminders` table to skip already-sent reminders
  - Fetches merchant/vendor names and contactable user emails
  - Sends reminder emails via Resend with a dedicated HTML template
  - Records each sent reminder to prevent duplicates
  - Returns a structured response with sent count, details, and any errors

- **`scripts/create-event-reminders-table.sql`** — SQL migration to create the `event_reminders` table with:
  - UUID primary key, `event_id` FK with cascade delete, `reminder_type` check constraint
  - `UNIQUE(event_id, reminder_type)` to enforce one reminder per type per event
  - RLS enabled with a service-role policy
  - Index on `event_id` for efficient lookups

### Modified Files
- **`types/index.ts`** — Added `ReminderType` union type and `EventReminder` interface

## Cron Setup

Add to cron-job.org (daily at 8 AM):
- URL: `https://www.dropby.dev/api/cron/send-event-reminders`
- Header: `Authorization: Bearer <CRON_SECRET value>`

## Testing

- Verified no new TypeScript errors introduced (pre-existing errors in `types/api.ts` are unrelated)
- Nuxt prepare and type generation succeed
- Follows existing cron endpoint patterns (`process-completed-events.ts`, `process-recurring-events.ts`)
- Follows existing email patterns (`sendBookingConfirmation.ts`)

Closes #65