### PR TITLE
Add beta tester emails per issue #67

### DIFF
--- a/scripts/add-beta-testers-issue-67.sql
+++ b/scripts/add-beta-testers-issue-67.sql
@@ -1,0 +1,8 @@
+-- Add beta testers requested in issue #67
+-- Uses ON CONFLICT to safely skip if the email already exists
+
+INSERT INTO beta_testers (email, notes)
+VALUES
+  ('eric.lorenzen@gmail.com', 'Added via issue #67'),
+  ('ericlorenzen@myyahoo.com', 'Added via issue #67')
+ON CONFLICT (email) DO NOTHING;


### PR DESCRIPTION
## Summary
- Adds a SQL migration script to insert two new beta tester email addresses into the `beta_testers` table
- Emails added: `eric.lorenzen@gmail.com` and `ericlorenzen@myyahoo.com`

## Changes
- **`scripts/add-beta-testers-issue-67.sql`** — New migration script that inserts both emails with `ON CONFLICT (email) DO NOTHING` for idempotent execution

## How to apply
Run the SQL script against the Supabase database:
```sql
-- Via Supabase SQL editor or psql
\i scripts/add-beta-testers-issue-67.sql
```

Closes #67