### PR TITLE
Send event request notification email on every request

### DIFF
--- a/components/event/Calendar.vue
+++ b/components/event/Calendar.vue
@@ -1004,7 +1004,7 @@ export default {
           throw new Error('Vendor or event information is missing')
         }
         
-        const result = await eventStore.requestEvent(eventOnDay.value.id, vendor.value.id, { sendEmail: true })
+        const result = await eventStore.requestEvent(eventOnDay.value.id, vendor.value.id)
         
         if (!result.success) {
           if (result.error === 'usage_limit') {
@@ -1059,7 +1059,7 @@ export default {
       
       loadingRequest.value = event.id
       try {
-        const result = await eventStore.requestEvent(event.id, vendor.value.id, { sendEmail: true })
+        const result = await eventStore.requestEvent(event.id, vendor.value.id)
         
         if (!result.success) {
           if (result.error === 'usage_limit') {

--- a/server/api/sendEventRequestNotification.ts
+++ b/server/api/sendEventRequestNotification.ts
@@ -1,11 +1,11 @@
-import { serverSupabaseClient } from '#supabase/server'
+import { serverSupabaseServiceRole } from '#supabase/server'
 import { Resend } from 'resend'
 
 const resend = new Resend(process.env.RESEND_API_KEY)
 
 export default defineEventHandler(async (event) => {
     try {
-        const client = await serverSupabaseClient(event)
+        const client = serverSupabaseServiceRole(event)
         const query = getQuery(event)
 
         // Validate required parameters
@@ -134,7 +134,7 @@ export default defineEventHandler(async (event) => {
 
         return { success: true, data: emailData }
         
-    } catch (error) {
+    } catch (error: any) {
         console.error('Event request notification error:', error)
         return { error: error.message || 'Failed to send event request notification' }
     }

--- a/stores/event.ts
+++ b/stores/event.ts
@@ -294,7 +294,7 @@ export const useEventStore = defineStore('event', {
       }
     },
 
-    async requestEvent(eventId: string, vendorId: string, options?: { sendEmail?: boolean }) {
+    async requestEvent(eventId: string, vendorId: string) {
       try {
         // Check usage limit before allowing request
         const usageCheck = await usageService.check({
@@ -376,8 +376,8 @@ export const useEventStore = defineStore('event', {
           }
         }
 
-        // Send email notification if requested
-        if (options?.sendEmail && event.merchant) {
+        // Send email notification to contactable merchant users
+        if (event.merchant) {
           try {
             await $fetch(`/api/sendEventRequestNotification?eventId=${eventId}&vendorId=${vendorId}&merchantId=${event.merchant}`)
           } catch (emailErr) {


### PR DESCRIPTION
## Summary
- Email notifications are now sent to contactable merchant users **every time** a vendor requests to work an event, not just from certain UI paths
- Updated the `sendEventRequestNotification` server endpoint to use `serverSupabaseServiceRole` instead of user-scoped `serverSupabaseClient`, following project conventions for server-side DB access

## What changed
- **`stores/event.ts`**: Removed the optional `sendEmail` parameter from `requestEvent()`. The email notification is now always fired (fire-and-forget with try/catch) whenever a vendor requests an event that has an associated merchant.
- **`server/api/sendEventRequestNotification.ts`**: Switched from `serverSupabaseClient` to `serverSupabaseServiceRole` for unrestricted service-role access. Added proper TypeScript error typing.
- **`components/event/Calendar.vue`**: Removed `{ sendEmail: true }` option from two `requestEvent` call sites, since email is now sent automatically.

## How it works
When a vendor requests an event via `requestEvent()` in the event store:
1. The vendor is added to the event's `pending_requests`
2. In-app notifications are created for all merchant users (existing behavior)
3. An email notification is sent via `/api/sendEventRequestNotification` to all contactable merchant users (`available_to_contact = true` with a valid email) — **now happens unconditionally**

The email includes event details (date, time, location) and vendor information (name, description, cuisine, contact info).

## Testing
- Verified all `requestEvent` call sites (Calendar.vue, AllEvents.vue, vendor events page) now trigger email notifications
- Confirmed no remaining references to the removed `sendEmail` option
- Verified the endpoint correctly queries contactable users and sends via Resend

Closes #75

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect outbound email behavior and increase the frequency of notifications, plus the API now runs with service-role DB privileges; misconfiguration could lead to over-emailing or broader data access than intended.
> 
> **Overview**
> Vendor event requests now *always* trigger an email notification to contactable merchant users by making `useEventStore.requestEvent()` fire `/api/sendEventRequestNotification` unconditionally (and removing the prior `sendEmail` option).
> 
> The `sendEventRequestNotification` API handler switches to `serverSupabaseServiceRole` for server-side DB reads, and UI call sites in `Calendar.vue` are updated to match the new `requestEvent(eventId, vendorId)` signature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07512b0f36291412422a91bc6d4d8d7c9efc8325. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->