### PR TITLE
Auto-capture pending external email input on event creation

### DIFF
--- a/components/event/Create.vue
+++ b/components/event/Create.vue
@@ -387,6 +387,11 @@ const createEvent = async () => {
       // Don't fail the event creation if usage tracking fails
     }
 
+    // Capture any valid email left in the input field that wasn't explicitly added
+    if (inviteVendors.value && externalEmailInput.value.trim()) {
+      addExternalEmail()
+    }
+
     // Send vendor invites if enabled
     const hadInvites = inviteVendors.value
     const inviteCount = selectedVendors.value.length + externalEmails.value.length


### PR DESCRIPTION
## Summary
- Fixes #79: External email input value is now captured at event creation time even if the user didn't explicitly press Enter or click the add button.

## What was changed
In `components/event/Create.vue`, added a call to `addExternalEmail()` in the `createEvent` function, right before processing vendor invites. This ensures that if the user typed a valid email address in the external invite input field but didn't submit it to the list (via Enter key or the + button), the email is still included when sending invites.

The existing `addExternalEmail()` function already handles:
- Trimming and lowercasing the input
- Splitting comma-separated emails
- Validating emails contain `@`
- Deduplicating against already-added emails
- Clearing the input field

So reusing it here is safe and consistent with the existing validation logic.

## Testing
- Verified that only `Create.vue` has the external email invite feature (not `CreateMultiple.vue` or `CreateRecurringEvent.vue`)
- The change only fires when `inviteVendors` is enabled and the input field is non-empty
- Invalid emails (no `@`) are filtered out by the existing validation in `addExternalEmail()`
- Duplicate emails are handled by the existing deduplication logic