### PR TITLE
Add loading spinners for action buttons in dialogs

### DIFF
--- a/components/AssociatedUsers.vue
+++ b/components/AssociatedUsers.vue
@@ -227,6 +227,7 @@ const submitEdits = async () => {
         phone: phone.value
     }
 
+    loading.value = true
     try {
         await store.updateUser(editId.value, userObj)
         snackbar.value = true
@@ -239,6 +240,8 @@ const submitEdits = async () => {
         errType.value = 'User Update(s)'
         errMsg.value = error.message || 'Failed to update user'
         errDialog.value = true
+    } finally {
+        loading.value = false
     }
 }
 const resetFields = () => {

--- a/components/event/Calendar.vue
+++ b/components/event/Calendar.vue
@@ -432,7 +432,7 @@
     />
 
     <ErrorDialog v-if="errDialog" :errType="errType" :errMsg="errMsg" @errorClose="errDialog = false" />
-    <DeleteDialog v-if="deleteDialog" :visible="deleteDialog" :itemType="'event'" @deleteConfirm="confirmDelete" @deleteCancel="cancelDelete" />
+    <DeleteDialog v-if="deleteDialog" :visible="deleteDialog" :itemType="'event'" :loading="deleting" @deleteConfirm="confirmDelete" @deleteCancel="cancelDelete" />
 
     <Toast group="main" position="bottom-center" @close="onClose" />
   </div>
@@ -527,6 +527,7 @@ export default {
     const errMsg        = ref()
     const errDialog     = ref(false)
     const deleteDialog  = ref(false)
+    const deleting      = ref(false)
     const loading       = ref(false)
     const loadingApproval = ref('')
     const loadingRejection = ref('')
@@ -871,6 +872,7 @@ export default {
     const promptDeletion = () => { deleteDialog.value = true }
     const confirmDelete = async () => {
         const eventStore = useEventStore()
+        deleting.value = true
         try {
             await eventStore.deleteEvent(eventOnDay.value.id)
             await resetFields('deleted')
@@ -878,6 +880,8 @@ export default {
             errType.value = 'Event Deletion'
             errMsg.value = error.message
             errDialog.value = true
+        } finally {
+            deleting.value = false
         }
         deleteDialog.value = false
     }
@@ -1217,6 +1221,7 @@ export default {
       errMsg,
       errDialog,
       deleteDialog,
+      deleting,
       loading,
       loadingRequest,
       loadingApproval,

--- a/components/event/DetailsCard.vue
+++ b/components/event/DetailsCard.vue
@@ -209,6 +209,7 @@
           label="Request Event"
           severity="success"
           icon="pi pi-send"
+          :loading="requestLoading"
         />
         <Button 
           @click="$emit('update:visible', false)"
@@ -240,6 +241,7 @@ interface Props {
   getVendorProp: (vendorId: string | null, prop: string) => string
   getVendorCuisines: (vendorId: string | null) => string[]
   hasReview: (event: Event) => boolean
+  requestLoading?: boolean
 }
 
 const props = defineProps<Props>()

--- a/components/menu/Table.vue
+++ b/components/menu/Table.vue
@@ -213,7 +213,7 @@
             <MenuEdit :item="itemToEdit" :vendor="user.associated_vendor_id" @edited="itemSuccess" @errored="itemErrored" />
         </Dialog>
 
-        <DeleteDialog v-if="deleteDialog" :visible="deleteDialog" :itemType="'Inventory Item'" @deleteConfirm="confirmDelete" @deleteCancel="cancelDelete" />
+        <DeleteDialog v-if="deleteDialog" :visible="deleteDialog" :itemType="'Inventory Item'" :loading="deleting" @deleteConfirm="confirmDelete" @deleteCancel="cancelDelete" />
         <ErrorDialog v-if="errDialog" :errType="errType" :errMsg="errMsg" @errorClose="errDialog = false" />
         <Toast group="main" position="bottom-center" @close="onClose" />
     </div>
@@ -238,6 +238,7 @@ const editDialog   = ref(false)
 const itemToEdit   = ref<any>(null)
 const itemToDelete = ref<any>(null)
 const deleteDialog = ref(false)
+const deleting     = ref(false)
 const errDialog    = ref(false)
 const errMsg       = ref()
 const errType      = ref()
@@ -323,11 +324,10 @@ const promptDeletion = (item:any) => {
 const confirmDelete = async () => {
     if (!itemToDelete.value) return
     
+    deleting.value = true
     try {
-        // Delete from database using store
         await store.deleteMenuItem(itemToDelete.value.id)
         
-        // Delete image from storage
         if (itemToDelete.value.image_name) {
             await storageStore.deleteImage('menu_images', itemToDelete.value.image_name)
         }
@@ -335,6 +335,8 @@ const confirmDelete = async () => {
         await resetFields('Deleted')
     } catch (error: any) {
         throwErr('Item Deletion', error.message || 'Failed to delete menu item')
+    } finally {
+        deleting.value = false
     }
 }
 const cancelDelete = () => {

--- a/components/settings/PaymentMethods.vue
+++ b/components/settings/PaymentMethods.vue
@@ -52,6 +52,7 @@
       <DeleteDialog
         :visible="showDeleteDialog"
         :itemType="'Payment Method'"
+        :loading="deletingPaymentMethod"
         @deleteCancel="handleDeleteCancel"
         @deleteConfirm="handleDeleteConfirm"
       />
@@ -71,6 +72,7 @@ const { showToast } = useToast()
 const paymentMethods = ref<any[]>([])
 const showAddDialog = ref(false)
 const showDeleteDialog = ref(false)
+const deletingPaymentMethod = ref(false)
 const paymentMethodToDelete = ref<string | null>(null)
 
 onMounted(async () => {
@@ -112,6 +114,7 @@ const handleDeleteCancel = () => {
 const handleDeleteConfirm = async () => {
     if (!paymentMethodToDelete.value) return
     
+    deletingPaymentMethod.value = true
     try {
         const response = await paymentService.detachPaymentMethod({
             paymentMethodId: paymentMethodToDelete.value
@@ -127,6 +130,7 @@ const handleDeleteConfirm = async () => {
         console.error('Error deleting payment method:', error)
         showToast('error', 'Error', 'Failed to delete payment method. Please try again.')
     } finally {
+        deletingPaymentMethod.value = false
         showDeleteDialog.value = false
         paymentMethodToDelete.value = null
     }

--- a/components/vendor/event/EventDetails.vue
+++ b/components/vendor/event/EventDetails.vue
@@ -76,6 +76,7 @@
                         v-if="!isPendingRequest"
                         label="Request Event"
                         icon="pi pi-send"
+                        :loading="loading"
                         @click="$emit('requestEvent', event)"
                         class="w-full md:w-auto"
                     />
@@ -85,6 +86,7 @@
                         icon="pi pi-times"
                         severity="danger"
                         outlined
+                        :loading="loading"
                         @click="$emit('cancelRequest', event)"
                         class="w-full md:w-auto"
                     />
@@ -102,6 +104,7 @@ const props = defineProps<{
     event: Event
     merchant?: Merchant
     vendorId?: string
+    loading?: boolean
 }>()
 
 const emit = defineEmits<{

--- a/pages/merchant/[id]/events.vue
+++ b/pages/merchant/[id]/events.vue
@@ -346,11 +346,13 @@
             label="Cancel" 
             severity="secondary" 
             outlined
+            :disabled="deletingEvent"
             @click="showDeleteEventDialog = false" 
           />
           <Button 
             label="Delete Event" 
             severity="danger"
+            :loading="deletingEvent"
             @click="confirmDeleteEvent"
             class="min-w-[120px]"
           />
@@ -432,6 +434,7 @@ const selectedEventForDetails = ref<Event | null>(null)
 // Delete event dialog state
 const showDeleteEventDialog = ref(false)
 const selectedEventForDelete = ref<Event | null>(null)
+const deletingEvent = ref(false)
 
 // Menu state
 const selectedEventForMenu = ref<Event | null>(null)
@@ -700,6 +703,7 @@ const deleteEvent = (event: Event) => {
 const confirmDeleteEvent = async () => {
   if (!selectedEventForDelete.value) return
   
+  deletingEvent.value = true
   try {
     const eventStore = useEventStore()
     await eventStore.deleteEvent(selectedEventForDelete.value.id)
@@ -709,6 +713,7 @@ const confirmDeleteEvent = async () => {
     console.error('Error deleting event:', error)
     showToast('error', 'Error', 'Failed to delete event. Please try again.')
   } finally {
+    deletingEvent.value = false
     showDeleteEventDialog.value = false
     selectedEventForDelete.value = null
   }

--- a/pages/merchant/[id]/ratings-and-reviews.vue
+++ b/pages/merchant/[id]/ratings-and-reviews.vue
@@ -247,6 +247,7 @@
     <DeleteDialog
       :visible="showDeleteDialog"
       item-type="Review"
+      :loading="deletingReview"
       @delete-cancel="closeDeleteDialog"
       @delete-confirm="confirmDeleteReview"
     />
@@ -357,6 +358,7 @@ const showPendingReviews = ref(false)
 
 // Delete review state
 const showDeleteDialog = ref(false)
+const deletingReview = ref(false)
 const selectedReviewForDelete = ref<DisplayReview | null>(null)
 
 // Computed properties
@@ -423,9 +425,8 @@ const closeDeleteDialog = () => {
 const confirmDeleteReview = async () => {
     if (!selectedReviewForDelete.value) return
     
+    deletingReview.value = true
     try {
-        loading.value = true
-        
         const reviewStore = useReviewStore()
         await reviewStore.deleteReview(selectedReviewForDelete.value.id)
         
@@ -436,7 +437,7 @@ const confirmDeleteReview = async () => {
         console.error('Error deleting review:', error)
         showToast('error', 'Error', 'Failed to delete review. Please try again.')
     } finally {
-        loading.value = false
+        deletingReview.value = false
     }
 }
 

--- a/pages/merchant/[id]/recurring-events.vue
+++ b/pages/merchant/[id]/recurring-events.vue
@@ -166,7 +166,8 @@
     <DeleteDialog 
       v-if="deleteDialog" 
       :visible="deleteDialog"
-      :itemType="'recurring event'" 
+      :itemType="'recurring event'"
+      :loading="deleting"
       @deleteConfirm="confirmDelete" 
       @deleteCancel="cancelDelete" 
     />
@@ -206,6 +207,7 @@ const selectedRecurringEvent = ref<any | null>(null)
 
 // Delete dialog state
 const deleteDialog = ref(false)
+const deleting = ref(false)
 const recurringEventToDelete = ref<any | null>(null)
 
 // Filter state
@@ -355,12 +357,12 @@ const promptDeletion = (recurringEvent: any) => {
 const confirmDelete = async () => {
   if (!recurringEventToDelete.value) return
   
+  deleting.value = true
   try {
     await recurringEventStore.deleteRecurringEvent(recurringEventToDelete.value.id)
     
     showToast('success', 'Recurring Event Deleted', 'The recurring event has been deleted successfully')
     
-    // Refresh the list
     await recurringEventStore.loadRecurringEventsByMerchantId(merchantId)
     
     deleteDialog.value = false
@@ -370,6 +372,8 @@ const confirmDelete = async () => {
     showToast('error', 'Delete Error', error.message || 'Failed to delete recurring event. Please try again.')
     deleteDialog.value = false
     recurringEventToDelete.value = null
+  } finally {
+    deleting.value = false
   }
 }
 

--- a/pages/vendor/[id]/ratings-and-reviews.vue
+++ b/pages/vendor/[id]/ratings-and-reviews.vue
@@ -157,6 +157,7 @@
     <DeleteDialog
       :visible="showDeleteDialog"
       item-type="Review"
+      :loading="deletingReview"
       @delete-cancel="closeDeleteDialog"
       @delete-confirm="confirmDeleteReview"
     />
@@ -274,6 +275,7 @@ const showPendingReviews = ref(false)
 
 // Delete review state
 const showDeleteDialog = ref(false)
+const deletingReview = ref(false)
 const selectedReviewForDelete = ref<DisplayReview | null>(null)
 
 const getEventTime = (eventId: string): string => {
@@ -306,6 +308,7 @@ const closeDeleteDialog = () => {
 const confirmDeleteReview = async () => {
     if (!selectedReviewForDelete.value) return
     
+    deletingReview.value = true
     try {
         await reviewStore.deleteReview(selectedReviewForDelete.value.id)
         
@@ -315,6 +318,8 @@ const confirmDeleteReview = async () => {
     } catch (error: any) {
         console.error('Error deleting review:', error)
         showToast('error', 'Error', 'Failed to delete review. Please try again.')
+    } finally {
+        deletingReview.value = false
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds loading spinners to action buttons in dialogs throughout the app to provide visual feedback during async operations
- Fixes the primary issue: the "Submit Edits" button in the Add/Edit User dialog (`AssociatedUsers.vue`) was missing loading state management
- Audited the entire codebase and added loading spinners to all identified buttons that trigger server calls without feedback

## Changes

### Primary Fix
- **`components/AssociatedUsers.vue`** — `submitEdits()` now sets `loading = true` before the async call and resets it in `finally`, matching the existing pattern in `inviteUser()`

### Additional Fixes (app-wide audit)
- **`components/event/Calendar.vue`** — Added `deleting` ref and passed `:loading` to `DeleteDialog` for event deletion
- **`components/menu/Table.vue`** — Added `deleting` ref and passed `:loading` to `DeleteDialog` for menu item deletion
- **`components/settings/PaymentMethods.vue`** — Added `deletingPaymentMethod` ref and passed `:loading` to `DeleteDialog` for payment method deletion
- **`pages/merchant/[id]/events.vue`** — Added `deletingEvent` ref with `:loading` and `:disabled` on the Delete Event dialog buttons
- **`pages/merchant/[id]/recurring-events.vue`** — Added `deleting` ref and passed `:loading` to `DeleteDialog` for recurring event deletion
- **`pages/vendor/[id]/ratings-and-reviews.vue`** — Added `deletingReview` ref and passed `:loading` to `DeleteDialog` for review deletion
- **`pages/merchant/[id]/ratings-and-reviews.vue`** — Added dedicated `deletingReview` ref (replacing shared `loading` ref that conflicted with page skeleton) and passed `:loading` to `DeleteDialog`
- **`components/vendor/event/EventDetails.vue`** — Added optional `loading` prop and bound it to Request Event / Cancel Request buttons
- **`components/event/DetailsCard.vue`** — Added optional `requestLoading` prop and bound it to the Request Event button

## Pattern
All fixes follow the same consistent pattern:
1. Add a dedicated `ref(false)` for the loading state
2. Set it to `true` before the `await` call
3. Reset it to `false` in a `finally` block
4. Bind it via PrimeVue's `:loading` prop on `Button` or `DeleteDialog`

Closes #83