### PR TITLE
Fix switch button styling in GetStarted.vue

### DIFF
--- a/components/GetStarted.vue
+++ b/components/GetStarted.vue
@@ -815,35 +815,42 @@ const throwErr = (title: string, msg: string) => {
     width: 100%;
 }
 
-/* Fix InputSwitch/ToggleSwitch visibility - PrimeVue v4 uses p-toggleswitch */
-:deep(.p-toggleswitch) {
+/* Fix InputSwitch/ToggleSwitch visibility — specificity must beat the
+   :deep(.p-stepper .p-stepper-panels *) nuclear selectors above (0,2,0). */
+:deep(.p-stepper .p-toggleswitch) {
     display: inline-block !important;
     width: 3rem !important;
     height: 1.75rem !important;
     visibility: visible !important;
     opacity: 1 !important;
+    background: transparent !important;
+    background-color: transparent !important;
 }
 
-:deep(.p-toggleswitch-slider) {
+:deep(.p-stepper .p-toggleswitch .p-toggleswitch-slider) {
     background: var(--p-surface-400) !important;
+    background-color: var(--p-surface-400) !important;
     border: 1px solid var(--p-surface-400) !important;
     border-radius: 30px !important;
 }
 
-:deep(.p-toggleswitch-slider:before) {
+:deep(.p-stepper .p-toggleswitch .p-toggleswitch-handle) {
     background: var(--p-surface-card) !important;
+    background-color: var(--p-surface-card) !important;
     width: 1.25rem !important;
     height: 1.25rem !important;
+    border-radius: 50% !important;
 }
 
-:deep(.p-toggleswitch.p-toggleswitch-checked .p-toggleswitch-slider) {
+:deep(.p-stepper .p-toggleswitch.p-toggleswitch-checked .p-toggleswitch-slider) {
     background: var(--p-primary-color) !important;
+    background-color: var(--p-primary-color) !important;
     border-color: var(--p-primary-color) !important;
 }
 
-:deep(.p-toggleswitch.p-toggleswitch-checked .p-toggleswitch-slider:before) {
+:deep(.p-stepper .p-toggleswitch.p-toggleswitch-checked .p-toggleswitch-handle) {
     background: var(--p-primary-contrast-color, var(--p-surface-card)) !important;
-    transform: translateX(1.25rem) !important;
+    background-color: var(--p-primary-contrast-color, var(--p-surface-card)) !important;
 }
 
 </style>


### PR DESCRIPTION
## Summary
- Fixed toggle switch buttons being invisible in GetStarted.vue onboarding stepper
- Root cause: "nuclear option" CSS selectors like `:deep(.p-stepper .p-stepper-panels *)` forced `background-color: var(--p-surface-ground)` on ALL descendant elements, including the toggle switch track and handle, making them blend into the background

## Changes
- Increased CSS specificity of toggle switch override selectors from `(0,1,0)` to `(0,3,0)` by nesting under `.p-stepper .p-toggleswitch`, so they beat the nuclear `(0,2,0)` selectors
- Updated selectors to target PrimeVue 4's actual DOM structure: `.p-toggleswitch-handle` (a real element) instead of `.p-toggleswitch-slider:before` (a pseudo-element that doesn't exist in PrimeVue 4)
- Added explicit `background: transparent` on the `.p-toggleswitch` root to prevent the ground color from bleeding through
- Applied both `background` and `background-color` properties for completeness against the nuclear selectors that set both

## Testing
- Verified CSS specificity calculations ensure the fix selectors win over all nuclear selectors
- Matched the working toggle switch pattern from AssociatedUsers.vue (which has no custom CSS and works with default PrimeVue styling)

Fixes #84